### PR TITLE
clean package

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,7 @@
 {
-  "presets": ["es2015", "stage-0"],
+  "presets": ["es2015"],
   "plugins": [
     "transform-object-assign",
-    "add-module-exports",
     "transform-class-properties"
   ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+node_modules/
+
 # Custom stuff
 _workspace
 

--- a/package.json
+++ b/package.json
@@ -3,23 +3,23 @@
   "version": "0.0.5",
   "description": "Giphy plugin for dext, a smart launcher powered by Javascript",
   "main": "index.js",
+  "files": [
+    "index.js",
+    "utils"
+  ],
   "dependencies": {
     "request": "^2.74.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.6.5",
-    "babel-core": "^6.7.2",
-    "babel-eslint": "^5.0.0",
-    "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-eslint": "^7.0.0",
     "babel-plugin-transform-class-properties": "^6.9.0",
     "babel-plugin-transform-object-assign": "^6.5.0",
     "babel-preset-es2015": "^6.6.0",
-    "babel-preset-stage-0": "^6.5.0",
-    "eslint": "^3.4.0",
+    "eslint": "^3.7.1",
     "ghooks": "^1.3.2"
   },
   "scripts": {
-    "lint": "$(npm bin)/eslint index.js"
+    "lint": "eslint index.js"
   },
   "keywords": [
     "dext",


### PR DESCRIPTION
General cleanup
- Removes unnecessary babel plugins and presets
- Shorten npm scripts
- Only pack `index.js`, and `utils`
- gitignore `node_modules`
